### PR TITLE
Change script_tag to defer

### DIFF
--- a/theme-app-extension/blocks/product-reviews.liquid
+++ b/theme-app-extension/blocks/product-reviews.liquid
@@ -43,7 +43,7 @@
   {% endif %}
 </div>
 
-{{ 'product-reviews-form.js' | asset_url | script_tag }}
+<script src="{{ 'product-reviews-form.js' | asset_url }}" defer></script>
 
 {% schema %}
 {


### PR DESCRIPTION
Resolves https://github.com/Shopify/product-reviews-sample-app/issues/7

```
X The script_tag filter is parser-blocking. Use a script tag with the async or defer attribute for better performance at blocks/product-reviews.liquid:46
```