### PR TITLE
Clean up extension related docs

### DIFF
--- a/docs/checkout-extension-post-purchase.md
+++ b/docs/checkout-extension-post-purchase.md
@@ -1,44 +1,54 @@
-# Post-Purchase Checkout Extensions
+# Installing the Post-Purchase Checkout Extensions
 
-Post-Purchase Checkout Extensions allow merchants to display an additional page between the checkout payment page and the thank-you page, prompting the customer to complete some additional action. In the case of this app, the extension asks the customer to submit a review for the product they just bought.
+This document contains steps on how to setup and install the post-purchase checkout extension for the Node.js application that was installed in the previous step. Each step in this document begins with a reason for why we're doing that step (_usually written like this_), then some instructions for the reader to perform.
 
-If you create a post-purchase checkout extension for your app, it will provide an option to display this additional page to any customer of a store that has your app installed.
+### About Post-Purchase Checkout Extensions
 
-If you want to test the Post-Purchase Checkout Extension locally, you must run it separately. Please note this is only necessary when testing locally, since the published extensions are hosted by Shopify.
+Post-Purchase Checkout Extensions allow merchants to **display an additional page between the checkout payment page and the thank-you page**, prompting the customer to complete some additional action. In the case of this app, the extension asks the customer to submit a review for the product they just bought.
+
+_The code for the post-checkout extension used for this repository is in the [checkout-extension](/checkout-extension) directory._
 
 ## Table of contents
 
-- [Checkout Extension Post-Purchase](#checkout-extension-post-purchase)
-  - [Running the checkout extension locally](#running-the-checkout-extension-locally)
-    - [Install dependencies](#install-dependencies)
-    - [Set up environment](#set-up-environment)
-    - [Start the server](#start-the-server)
-    - [Set up the browser extension](#set-up-the-browser-extension)
-  - [Publishing](#publishing)
-  - [Scaffolding New Checkout Extensions](#scaffolding-new-checkout-extensions)
-  - [Additional Resources](#additional-resources)
+1. [Authenticate with the CLI](#1-authenticate-with-the-cli)
+1. [Create a `.env` file](#2-create-env-file)
+1. [Install the `checkout-ui-extension-run` library](#3-install-the-checkout-ui-extension-run-library)
+1. [Update `embeddedAppHost` variable](#4-update-embeddedapphost-variable)
+1. [Register the extension](#5-register-the-extension)
+1. [Push the extension](#6-push-the-extension)
+1. [Publish the extension](#7-publish-the-extension)
+1. [Enable the extension](#8-enable-the-extension)
+1. [Verify the extension](#9-verify-the-extension)
 
-## Authenticate
+## 1. Authenticate with the CLI
 
-Run `shopify login` command. If you have multiple accounts add `--shop` flag like this, to specify development store on which you'll test, like this: `shopify login --shop=your-shop-name.myshopify.com`.
+_Before registering our extension with our store we should ensure the `shopify` CLI is authenticated._
 
-Command will give you authentication URL that you need to open in the browser. Once it authenticates you can return to Terminal where you ran initial CLI command.
+Run the `shopify login` command. The command will return a URL that you need to open in a browser. Once authenticated you can return to the terminal.
 
-Make sure you are logged in by running the Shopify CLI command
+```bash
+shopify login
+```
+
+If you have multiple accounts add a `--shop=<shop-url>` flag like this:
 
 ```bash
 shopify login --shop=your-test-shop-name.myshopify.com
 ```
 
-## Register the Post-Purchase Checkout Extension to your app
+## 2. Create a `.env` file
+
+_The extension we're building will need to an API key and secret. To supply these credentials create a `.env` file in the same directory as the extension._
+
+Go into the extension directory and create the `.env` file:
 
 ```bash
 cd checkout-extension && touch .env
 ```
 
-Add the following environment variables to the `.env` to connect the extension to your app:
+Add the following environment variables to the `.env` file:
 
-```
+```ini
 # Your app's API Key. You can find this in your partner dashboard or copy it from the node app .env
 SHOPIFY_API_KEY=1234
 # Your app's API. Secret You can find this in your partner dashboard or copy it from the node app .env
@@ -47,65 +57,78 @@ SHOPIFY_API_SECRET=abcdefg
 EXTENSION_TITLE=my-checkout-extension
 ```
 
-### Install dependencies
+### 3. Install the `checkout-ui-extension-run` library
 
-From the extension root folder, install the dependencies:
+_The step installs the [checkout-ui-extensions-run](https://www.npmjs.com/package/@shopify/checkout-ui-extensions-run) library, which adds functionality to the `shopify` CLI._
+
+From the `checkout-extension` folder, run the following command:
 
 ```bash
 npm install
 ```
 
-### Update the `embeddedAppHost` variable
+### 4. Update `embeddedAppHost` variable
 
-In the `src/index.js` file the variable `embeddedAppHost` is currently hardcoded. This needs to be updated to reflect the URL that `ngrok` generated.
+_The extension needs to know where the main application is being hosted, this is managed via a variable._
 
-## Register the extension
+Open the [`src/index.js`](/checkout-extension/src/index.js) file and update the variable `embeddedAppHost` to reflect the URL that `ngrok` generated. It should look like the following:
 
-Register the extension by running the Shopify CLI command
+```javascript
+const embeddedAppHost = "https://3db4-76-68-94-203.ngrok.io";
+```
+
+## 5. Register the extension
+
+_Registering your app extension associates it with an app in your Partner organization. This step should be done only once for each app extension._
+
+To register the extension, run the following command:
 
 ```bash
 shopify extension register
 ```
 
-## Push the extension
+## 6. Push the extension
 
-_This will build and compile a production version and push it to the Shopify CDN. (You should see that a build folder has been created with your minified code inside)._
+_Pushing the extension entails of building and compiling a production version of the extension, which is then pushed to the Shopify CDN. (You should see that a build folder has been created with your minified code inside)._
+
+To push the extension, run the following command:
 
 ```bash
 shopify extension push
 ```
 
-You should now see the extension in your app page in your Partner Dashboard under _Extensions_ > _<Your Checkout Name>_.
+## 7. Publish the extension
 
-## Publish the extension
+_When you're ready to release your extension you can publish it._
 
-Once your Theme App Extension code is ready for public use, push the latest code, head to _Extensions > Online Store > Post Check App Extensions_ under your App, click on the extension name, then click _Create Version_ button and once new version appears in your versions list simply click _Publish_ next to it.
+The publish the extension navigate to the following:
 
-## Enable the Post Checkout extension
+_***Partner Dashboard*** > Apps > ***Your App Name*** > Extensions > ***Your Checkout Extension Name***._
 
-One final step is to enable the checkout extension from the Store's admin settings. To do that, go to the _Store Admin Settings_ > _Checkout_ and select the extension you created.
+Once on the extension page, click on the **_Create version_** button and when the new version appears in the version list, click **_Publish_** next to it.
+
+> :exclamation: To save time, you can preview a draft of your app extension in a development store before creating a version by selecting the **_DEVELOPMENT STORE PREVIEW_** option from the extension's settings page.
+
+## 8. Enable the extension
+
+_By default, extensions are not enabled for online stores, we'll need to change our store's setting to use our new extension._
+
+The enable the extension navigate to the following:
+
+_***Store Admin Settings*** > Checkout > ***Your Checkout Extension Name***_
 
 ![Checkout menu](images/pc-menu.png)
 
-## Verify the Post Checkout extension
+## 9. Verify the extension
 
-> :question: You'll need to setup your test store to accept _test_ orders. [Follow this short doc](https://help.shopify.com/en/manual/checkout-settings/test-orders)
+_The last step is to verify that the extension is working as-expected. :question: Note that you'll need to ***setup your test store to accept test orders***. [Follow this short doc](https://help.shopify.com/en/manual/checkout-settings/test-orders) to enable test orders._
 
-To verify the post checkout extension is working add a product from the store to your cart and check out. Pay using a bogus gateway and when the order is placed you'll be prompted to leave a rating and review.
+From your online store, add a product to your cart and checkout. Pay using a bogus gateway and when the order is placed you'll be prompted to leave a rating and review.
 
-> :exclamation: The extension will only be triggered when a product that **has a price** is purchased. It will not work with a free product.
+> :exclamation: The extension will only be triggered when a product **has a price**. It will not work with a free product.
 
 ![post checkout working](images/post-checkout-final.png)
 
-## Further information
+## Summary
 
-- [CLI Extension Commands](https://shopify.dev/apps/tools/cli/extension-commands)
-- [Extension Versioning](https://shopify.dev/apps/app-extensions#app-extension-versioning)
-
-## Scaffolding New Checkout Extensions
-
-The Shopify CLI will scaffold the extension when you run `shopify create extension --type=CHECKOUT_POST_PURCHASE --name="checkout-extension"`. This should be done inside your embedded app, so that the extension is built as a subdirectory.
-
-## Additional Resources
-
-[Post-Purchase Checkout Extension Documentation](https://shopify.dev/apps/checkout/post-purchase)
+:tada: Congratulations! If you've reached this step you've completed the last of the tutorials! Go forth and build!

--- a/docs/theme-app-extension.md
+++ b/docs/theme-app-extension.md
@@ -1,38 +1,51 @@
-# Theme App Extension
+# Installing the Theme App Extension
+
+This document contains steps on how to setup and install the theme app extension for the Node.js application that was installed in the previous step. Each step in this document begins with a reason for why we're doing that step (_usually written like this_), then some instructions for the reader to perform.
+
+### About Theme App Extensions
 
 Theme App Extensions allow you to extend a theme by adding App Blocks to it. Theme App extensions are tied together with an app, so in order to build a theme app extension you need to have an app to register the extension under. **An app can have only one theme app extension. Once registered it cannot be unregistered**
 
-We recommend to keep all of your app extensions in the same repository as the embedded app. When using the CLI to generate an extension, it will create a dedicated directory it. For this reason it is advised to simply run the `shopify extension create` commands from the root directory of your project.
-
-To create Theme App Extension follow these steps below.
+_The code for the theme app extension used for this repository is in the [theme-app-extension](/theme-app-extension) directory._
 
 ## Table of contents
 
-- [Theme App Extension](#theme-app-extension)
-  - [Table of contents](#table-of-contents)
-  - [Authenticate](#authenticate)
-  - [Create an extension](#create-an-extension)
-  - [Register an extension](#register-an-extension)
-  - [Push the extension](#push-the-extension)
-  - [Publish](#publish)
-  - [Common errors](#common-errors)
-  - [FAQ](#faq)
+1. [Authenticate with the CLI](#1-authenticate-with-the-cli)
+1. [Create a `.env` file](#2-create-env-file)
+1. [Register the extension](#3-register-the-extension)
+1. [Push the extension](#4-push-the-extension)
+1. [Publish the extension](#5-publish-the-extension)
+1. [Verify the extension](#6-verify-the-extension)
 
-## Register the theme extension to your app
+## 1. Authenticate with the CLI
 
-Create a `.env` file in the root of the `theme-app-extension` folder
+_Before registering our extension with our store we should ensure the `shopify` CLI is authenticated._
 
-> :question: If you were creating a new extension this would get automatically generated, but since we are registering an existing one we must create it ourselves.
->
-> :book: For more information refer to the [theme app extension framework file structure](https://shopify.dev/apps/online-store/theme-app-extensions/extensions-framework#file-structure).
+Run the `shopify login` command. The command will return a URL that you need to open in a browser. Once authenticated you can return to the terminal.
+
+```bash
+shopify login
+```
+
+If you have multiple accounts add a `--shop=<shop-url>` flag like this:
+
+```bash
+shopify login --shop=your-test-shop-name.myshopify.com
+```
+
+## 2. Create a `.env` file
+
+_The extension we're building will need to an API key and secret. To supply these credentials create a `.env` file in the same directory as the extension._
+
+Go into the extension directory and create the `.env` file:
 
 ```bash
 cd theme-app-extension && touch .env
 ```
 
-Add the following environment variables to the `.env` to connect the extension to your app:
+Add the following environment variables to the `.env` file:
 
-```
+```ini
 # Your app's API Key. You can find this in your partner dashboard
 SHOPIFY_API_KEY=1234
 # Your app's API. Secret You can find this in your partner dashboard
@@ -41,49 +54,51 @@ SHOPIFY_API_SECRET=abcdefg
 EXTENSION_TITLE=my-theme-extension
 ```
 
-## Authenticate
+> :question: If we were creating a new extension a `.env` file would be generated automatically. However, since the extension already exists we must create the file instead.
+>
+> :book: For more information refer to the [theme app extension framework file structure](https://shopify.dev/apps/online-store/theme-app-extensions/extensions-framework#file-structure).
 
-Run `shopify login` command. If you have multiple accounts add `--shop` flag like this, to specify development store on which you'll test, like this: `shopify login --shop=your-shop-name.myshopify.com`.
+## 3. Register the extension
 
-Command will give you authentication URL that you need to open in the browser. Once it authenticates you can return to Terminal where you ran initial CLI command.
+_Registering your app extension associates it with an app in your Partner organization. This step should be done only once for each app extension._
 
-Make sure you are logged in by running the Shopify CLI command
-
-```bash
-shopify login --shop=your-test-shop-name.myshopify.com
-```
-
-## Register an extension
-
-_Run `shopify extension register` to register your Theme App Extension under your app. It will then appear in your Shopify Partners dashboard under your App \_Extensions > Online Store > Theme App Extensions_. From there you can enable 'DEVELOPMENT STORE PREVIEW' while you are building your extension. When you are ready to release your theme app extension create you can release versions or publish/unpublish them in the same spot. Until published other merchants won't be able to use those versions of the extension.\_
-
-Register the extension by running the Shopify CLI command
+To register the extension, run the following command:
 
 ```bash
 shopify extension register
 ```
 
-## Push the extension
+## 4. Push the extension
 
-From this point you can either push existing sample code of Theme App Extension to make it available for new version creation and also usage in development stores, or you can first modify/create your blocks, snippets and etc., and then push them (and create version, or publish if needed). Pushing is done using: `shopify extension push` command. If you have Development Store Preview enabled you will be able to see your changes immediately after pushing.
+_Pushing the extension entails of building and compiling a production version of the extension, which is then pushed to the Shopify CDN. (You should see that a build folder has been created with your minified code inside)._
 
-Push the extension by running to Shopify by running the Shopify CLI command
+To push the extension, run the following command:
 
 ```bash
 shopify extension push
 ```
 
-## Publish the extension
+## 5. Publish the extension
 
-Once your Theme App Extension code is ready for public use, push the latest code, head to _Extensions > Online Store > Theme App Extensions_ under your App, click on the extension name, then click _Create Version_ button and once new version appears in your versions list simply click _Publish_ next to it.
+_When you're ready to release your extension you can publish it._
 
-## Verify the extension is working
+The publish the extension navigate to the following:
 
-To verify that the extension is working navigate to a product that has reviews. You'll be able to see reviews and ratings from users.
+_***Partner Dashboard*** > Apps > ***Your App Name*** > Extensions > ***Your Theme Extension Name***._
+
+Once on the extension page, click on the **_Create version_** button and when the new version appears in the version list, click **_Publish_** next to it.
+
+> :exclamation: To save time, you can preview a draft of your app extension in a development store before creating a version by selecting the **_DEVELOPMENT STORE PREVIEW_** option from the extension's settings page.
+
+## 6. Verify the extension
+
+_The last step is to verify that the extension is working as-expected._
+
+From your online store navigate to a product that has at least one published review. You should now be able to see reviews and ratings from users.
 
 ![](images/theme-extension-final.png)
 
-## [Optional] Add theme support detection to the embedded application
+## 7. (Optional) Add theme support detection to the embedded application
 
 A quick way to check if things are set up correctly is to perform the steps below. This will show if your theme and store can use the extension, the results will be shown in the embedded application.
 
@@ -95,19 +110,31 @@ A quick way to check if things are set up correctly is to perform the steps belo
 
 Congratulations! If you've reached this step you've deployed the theme extension. Go to the next step, [Adding a Post Checkout Extension](checkout-extension-post-purchase), to add reviews after a customer has purchased a product.
 
-## Common errors
+## FAQ
 
-**Incorrect schema of the block**
+**Q: I'm getting a 401 error code, what's wrong?**
 
-CLI will infrom you about the issue and what is wrong when trying to push your code changes. Go on and fix those issues and push afterwards.
+A: This means your authentication session has expired and you need to rerun `shopify login`.
 
-**401 error code**
+**Q: I can't see my app blocks in my Theme Editor.**
 
-This means your authentication session has expired and you need to rerun `shopify login`.
+A: After you use the CLI command `shopify extension push` you must go to the extension page in the partner dashboard. Create a new version of the extension. Publish the version, to push it live to merchants.
 
-**Cannot see blocks in theme editor**
+**Q: I added the product reviews block but the I cannot see the add reviews form.**
 
-In order to make blocks visible in your theme editor you need to add `@app` in blocks under needed section schema. Also you'll need to add in order to make it render where you need in the UI:
+A: In the App Block settings in the Theme Editor ensure `Allow unverified review submissions` is selected.
+
+**Q: I'm seeing an `incorrect schema of the block` error, what's wrong?**
+
+A: The CLI will infrom you about the issue and what is wrong when trying to push your code changes. Go on and fix those issues and push afterwards.
+
+**Q: I cannot see the average review block**
+
+A: The average review block will appear once at least one review has been submitted and approved. You must approve the review in the app admin.
+
+**Q: I cannot see blocks in the theme editor**
+
+A: In order to make blocks visible in your theme editor you need to add `@app` in blocks under needed section schema. Also you'll need to add in order to make it render where you need in the UI:
 
 ```liquid
 {%- for block in section.blocks -%}
@@ -135,17 +162,3 @@ Then in the html template code portion you'll find the `{%- for block in section
 ```
 
 You should then see your blocks in theme editor under product page product section and if you'll select one of the blocks it will appear in sidepannel where Name, Price and other info about the product is present.
-
-## FAQ
-
-**Q: I can't see my app blocks in my Theme Editor.**
-
-A: After you use the CLI command `shopify extension push` you must go to the extension page in the partner dashboard. Create a new version of the extension. Publish the version, to push it live to merchants.
-
-**Q: I added the product reviews block but the I cannot see the add reviews form.**
-
-A: In the App Block settings in the Theme Editor ensure `Allow unverified review submissions` is selected.
-
-**Q: I cannot see the average review block**
-
-A: The average review block will appear once at least one review has been submitted and approved. You must approve the review in the app admin.


### PR DESCRIPTION
This PR modifies the extension related docs to look and feel like the
doc for the main embedded app. In general it reduces some of the
cruft and makes them as similar as possible since, it's best that the
theme and checkout extensions should have similar steps.

Signed-off-by: Steve Martinelli <steve.martinelli@shopify.com>