### PR TITLE
Use Standard Product Review Rating Metafield

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -4,13 +4,15 @@ export const METAFIELD_NAMESPACE = {
   publicReviews: "prapp-pub-reviews",
   privateReviews: "prapp-pvt-reviews",
   messages: "prapp-messages",
+  standardRating: "reviews",
 };
 
 // graphql queries will add/delete/update data under these keys in the
 // METAFIELD_NAMESPACE.general namespace
 export const METAFIELD_KEY = {
-  ratings: "ratings",
+  ratings: "rating",
   avgRating: "avg_rating",
+  standardRatingCount: "rating_count",
 };
 
 // Event types used by the PRODUCTS_UPDATE webhook (server.js)

--- a/server/handlers/mutations/update-product-avg-rating.js
+++ b/server/handlers/mutations/update-product-avg-rating.js
@@ -1,14 +1,19 @@
 import "isomorphic-fetch";
 import { gql } from "apollo-boost";
 import { METAFIELD_DELETE, PRODUCT_METAFIELD_CREATE } from "../../../graphql";
-import { METAFIELD_KEY, METAFIELD_NAMESPACE } from "../../../constants";
+import {
+  METAFIELD_KEY,
+  METAFIELD_NAMESPACE,
+  MAX_RATING,
+  MIN_RATING,
+} from "../../../constants";
 
 const GET_PRODUCT_AVG_RATING_METAFIELD = gql`
   query GetProductAvgRatingMetafield($productId: ID!) {
     product(id: $productId) {
       avgRatingMetafield: metafield(
-        namespace: "${METAFIELD_NAMESPACE.general}",
-        key: "${METAFIELD_KEY.avgRating}"
+        namespace: "${METAFIELD_NAMESPACE.standardRating}",
+        key: "${METAFIELD_KEY.ratings}"
       ) {
         id
         key
@@ -43,10 +48,14 @@ export const updateProductAvgRating = async (client, productId, avgRating) => {
         id: productId,
         metafields: [
           {
-            namespace: METAFIELD_NAMESPACE.general,
-            key: METAFIELD_KEY.avgRating,
-            value: String(avgRating),
-            valueType: "STRING",
+            namespace: METAFIELD_NAMESPACE.standardRating,
+            key: METAFIELD_KEY.ratings,
+            value: JSON.stringify({
+              value: avgRating,
+              scale_min: MIN_RATING,
+              scale_max: MAX_RATING,
+            }),
+            valueType: "JSON_STRING",
           },
         ],
       },

--- a/theme-app-extension/blocks/average-rating.liquid
+++ b/theme-app-extension/blocks/average-rating.liquid
@@ -1,4 +1,4 @@
-{% assign avg_rating = block.settings.product.metafields.prapp.avg_rating | plus: 0 %}
+{% assign avg_rating = block.settings.product.metafields.reviews.rating.value.rating | plus: 0 %}
 
 {% if avg_rating > 0 %}
 <div class="prapp-average-block" style="padding: {{ block.settings.padding_y }}px {{ block.settings.padding_x }}px;" data-product-id="{{ block.settings.product.id }}">

--- a/theme-app-extension/blocks/product-reviews.liquid
+++ b/theme-app-extension/blocks/product-reviews.liquid
@@ -1,7 +1,7 @@
 {{ 'style.css' | asset_url | stylesheet_tag }}
 {{ 'star-rating.css' | asset_url | stylesheet_tag }}
 
-{% assign avg_rating = block.settings.product.metafields.prapp.avg_rating | plus: 0 %}
+{% assign avg_rating = block.settings.product.metafields.reviews.rating.value.rating | plus: 0 %}
 {% assign reviews = block.settings.product.metafields.prapp-pub-reviews %}
 
 <div class="prapp-block" style="padding: {{ block.settings.padding_y }}px {{ block.settings.padding_x }}px;" data-product-id="{{ block.settings.product.id }}">


### PR DESCRIPTION
Closes #28 

### What does this do?
* Update the average product rating to use the Standard rating metafield: `reviews.rating`
* Updates the mutation to create the metafield
* Updates the theme app extensions blocks to read from the new metafields

### Why?
* Using standard metafields allows the information to be more visible across themes and apps. Other apps or themes would have a standard way to access this information

### How to test?
* This should not change the functionality of the app going forward.
* Product reviews would not be taken into affect to calculate the new average rating