### PR TITLE
Add mention of online store 2.0 to "Extending the app with a Theme Extension"

### DIFF
--- a/docs/theme-app-extension.md
+++ b/docs/theme-app-extension.md
@@ -105,6 +105,8 @@ From the **_Apps_** block, choose to add the "**_Average Review Score_**" and th
 
 ![add theme blocks](images/theme-blocks.png)
 
+> :exclamation: Theme App Extensions can only integrate with Online Store 2.0 themes such as the default Dawn theme, which is Shopify's Online Store 2.0 reference theme.
+
 ## 7. Verify the extension
 
 _The last step is to verify that the extension is working as-expected._


### PR DESCRIPTION
Hey folks 👋 

I was testing out the [The Extending the app with a Theme App Extension](https://github.com/Shopify/product-reviews-sample-app/blob/main/docs/theme-app-extension.md) guide today and came across a potential gotcha for folks following along.

I previously had installed a non Online Store 2.0 Theme in my store, and for a wee while I was wondering why I couldn't see the Sample App showing in the theme customiser when I was going through the guide. 

Turns out it seems it was because I didn't have an published Online Store 2.0 theme on my store 😆  

Just adding this PR for the note to `theme-app-extension.md` so others don't fall into the same trap as they are following along with the guide.

Should look like so -

[![alt](https://screenshot.click/07-42-yocxi-97ukn.png)](https://screenshot.click/07-42-yocxi-97ukn.png)

Maybe it could be included in the FAQ, but I encountered this issue when going through Step 6...anyway, just a thought :) 